### PR TITLE
Handle the url pattern lightning/r/<sObject ID>/view

### DIFF
--- a/pretty-urls-in-salesforce.js
+++ b/pretty-urls-in-salesforce.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         SFDC Pretty URLs
-// @namespace    github.com/msmeeks/pretty-urls-in-salesforce
+// @namespace    http://tampermonkey.net/
 // @version      0.1
-// @description  Convert SFDC URLs to their short form in the Lightning Experience
-// @author       msmeeks
+// @description  Convert SFDC URLs to their short form
+// @author       You
 // @match        https://*.lightning.force.com/*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js
 // @grant        none
@@ -50,14 +50,17 @@
             )
         );
     }
-
     function convertUrl(link) {
         var objectId;
+
         if (~link.origin.indexOf("lightning")) {
             var urlParts = link.href.split("/");
+            var indexOfr = urlParts.indexOf("r");
             var indexOfSObject = urlParts.indexOf("sObject");
             var indexOfAlohaRedirect = urlParts.indexOf("alohaRedirect");
-            if (indexOfSObject > 0) {
+            if (indexOfr > 0) {
+                objectId = urlParts[indexOfr + 1];
+            } else if (indexOfSObject > 0) {
                 objectId = urlParts[indexOfSObject + 1];
             } else if (indexOfAlohaRedirect > 0) {
                 objectId = urlParts[indexOfAlohaRedirect + 1].split("?")[0];

--- a/pretty-urls-in-salesforce.js
+++ b/pretty-urls-in-salesforce.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         SFDC Pretty URLs
-// @namespace    http://tampermonkey.net/
+// @namespace    github.com/msmeeks/pretty-urls-in-salesforce
 // @version      0.1
-// @description  Convert SFDC URLs to their short form
-// @author       You
+// @description  Convert SFDC URLs to their short form in the Lightning Experience
+// @author       msmeeks
 // @match        https://*.lightning.force.com/*
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js
 // @grant        none
@@ -50,6 +50,7 @@
             )
         );
     }
+
     function convertUrl(link) {
         var objectId;
 


### PR DESCRIPTION
This changeset updates the script to handle the lightning/r/<sObject ID>/view pattern.

It appears that this fix will allow the script to work in both lightning console and traditional lightning app views.